### PR TITLE
Basic working functionality

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,34 +1,84 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TypeOperators       #-}
 
 module Main where
 
-import Data.Aeson ((.:), (.=))
-import qualified Data.Aeson as Aeson
-import Data.ByteString (ByteString)
-import Data.Text (Text)
-import qualified Data.Time as Time
-import qualified Data.Time.Format as Time
-import Data.Proxy (Proxy(..))
-import GHC.Generics (Generic)
+import           Control.Concurrent.MVar  (MVar, newMVar, withMVar)
+import           Control.Exception        (SomeException, try)
+import           Control.Lens             (makeLenses, non, to, (^.), (^?))
+import           Control.Monad            (forM, join)
+import           Control.Monad.IO.Class   (liftIO)
+import           Data.Aeson               ((.:), (.=))
+import qualified Data.Aeson               as Aeson
+import           Data.ByteString          (ByteString)
+import qualified Data.ByteString          as BS
+import qualified Data.ByteString.Lazy     as BSL
+import           Data.Foldable            (find)
+import           Data.List                (sort)
+import           Data.Maybe               (fromMaybe)
+import           Data.Monoid              ((<>))
+import           Data.Ord                 (comparing)
+import           Data.Proxy               (Proxy (..))
+import           Data.Text                (Text)
+import qualified Data.Text                as T
+import qualified Data.Time                as Time
+import qualified Data.Time.Format         as Time
+import           GHC.Generics             (Generic)
 import qualified Network.Wai.Handler.Warp as Warp
-import Servant
-import Servant.Swagger
-import System.Environment (getArgs)
-import qualified Text.URI as URI
+import           Options.Generic
+import qualified Options.Generic          as Opts
+import           Path                     hiding ((</>))
+import           Path.IO                  (createTempDir, listDir)
+import           Servant
+import           Servant.Swagger
+import           System.Exit              (ExitCode (..))
+import           System.FilePath          ((</>))
+import           System.Process           (callProcess, cwd, proc,
+                                           readCreateProcess,
+                                           readCreateProcessWithExitCode, shell)
+import qualified Text.URI                 as URI
+
+data RuntimeOptions w = RuntimeOptions
+  { _serverPort :: w ::: Maybe Int <?> "Port on which to host the server."
+  , _repositoryUrl :: w ::: Text <?> "Authoritative server hosting the SLURP repository"
+  , _repositoryCacheDir :: w ::: Text <?> "Where to cache the git repo locally"
+  } deriving (Generic)
+
+instance ParseRecord (RuntimeOptions Opts.Wrapped) where
+  parseRecord = parseRecordWithModifiers lispCaseModifiers
+deriving instance Show (RuntimeOptions Opts.Unwrapped)
+
+$(makeLenses ''RuntimeOptions)
 
 type PackageAPI
-  = "packages" :> Get '[JSON] [Package] :<|>
-    "package" :> Capture "name" Text :> Get '[JSON] Package
+  = "packages" :> Get '[JSON] [Package]
+  :<|> "packages" :> ReqBody '[JSON] Package :> Post '[JSON] AddPackageResponse
+
+-- | Scheme through which this package's versions are served
+data Scheme
+  = Hackage
+  | Git
+  deriving (Eq, Show, Generic)
+
+instance Aeson.ToJSON Scheme
+instance Aeson.FromJSON Scheme
 
 data Package = Package
-  { name :: Text
+  { name     :: Text
   , location :: URI.URI
-  , date :: Time.UTCTime
+  , date     :: Time.UTCTime
+  , scheme   :: Scheme
   } deriving (Eq, Show, Generic)
+
+instance Ord Package where
+  compare = comparing name
 
 instance Aeson.ToJSON Package where
   toJSON Package{..} = Aeson.object
@@ -39,6 +89,7 @@ instance Aeson.ToJSON Package where
           Time.defaultTimeLocale
           (Time.iso8601DateFormat (Just "%H:%M:%SZ"))
           date
+    , "scheme" .= show scheme
     ]
 
 instance Aeson.FromJSON Package where
@@ -47,19 +98,108 @@ instance Aeson.FromJSON Package where
     <*> (do
       txt <- v .: "location"
       case URI.mkURI txt of
-        Left exc -> fail (show exc)
+        Left exc  -> fail (show exc)
         Right uri -> return uri)
     <*> v .: "date"
+    <*> v .: "scheme"
+
+data Repository = Repository
+  { repoPath      :: Path Abs Dir
+    -- | Path to the git executable
+  , repoGit       :: String
+    -- | Lock to ensure that only one thread may write to the repo at a given time
+  , repoWriteLock :: MVar ()
+  }
+
+-- | Take the write lock on the repo
+withRepoLock :: Repository -> (Path Abs Dir -> IO a) -> IO a
+withRepoLock (Repository path _git lock) f = withMVar lock $ \() -> f path
+
+-- | Initialise a local clone of the authoritative repository
+initRepository :: RuntimeOptions Opts.Unwrapped -> IO Repository
+initRepository ro = do
+  rootDir <- parseAbsDir $ ro ^. repositoryCacheDir . to T.unpack
+  cacheDir <- createTempDir rootDir "slurp"
+  git <- readCreateProcess (shell "which git") ""
+  callProcess git ["clone", ro ^. repositoryUrl . to T.unpack, toFilePath cacheDir]
+  lock <- newMVar ()
+  return $ Repository cacheDir git lock
+
+-- | Sync the clone with upstream master
+syncRepository :: Repository -> IO ()
+syncRepository r = withRepoLock r $ \repo -> do
+  (ec, _, _) <-
+    readCreateProcessWithExitCode
+      (proc (repoGit r) ["pull", "origin", "master"]) { cwd = Just $ toFilePath repo }
+      ""
+  case ec of
+    ExitSuccess   -> return ()
+    ExitFailure _ -> error "Failed to sync upstream repository"
+
+data AddPackageResponse
+  = PackageAdded
+  | PackageAlreadyOwned Package
+  | PackageNameInvalid
+  deriving (Eq, Generic, Show)
+
+instance Aeson.FromJSON AddPackageResponse
+instance Aeson.ToJSON AddPackageResponse
+
+-- | Add a package. This will:
+--   - Sync the repository
+--   - Load the correct file
+--   - Insert the new record
+--   - Rewrite the file
+--   - Do a git commit
+--   - Push to upstream
+addPackage :: Repository -> Package -> IO AddPackageResponse
+addPackage repo package = do
+  syncRepository repo
+  let indexChar = T.index (name package) 0
+      packageFile = toFilePath (repoPath repo) </> [indexChar]
+      git = repoGit repo
+  currentPackages <-
+    either (\(_:: SomeException) -> []) (fromMaybe [] . Aeson.decodeStrict)
+    <$> try (BS.readFile packageFile)
+  case find (\p -> name p == name package) currentPackages of
+    Nothing -> let newPackages = sort $ package : currentPackages in
+      withRepoLock repo $ \path -> do
+        BSL.writeFile packageFile $ Aeson.encode newPackages
+        readCreateProcessWithExitCode
+          (proc git [ "commit", "-m"
+                      , "Add package " <> (T.unpack $ name package)
+                      ])
+          { cwd = Just $ toFilePath path }
+          ""
+        readCreateProcessWithExitCode
+          (proc git ["push", "origin", "master"])
+          { cwd = Just $ toFilePath path }
+          ""
+        return $ PackageAdded
+
+    Just exists -> return $ PackageAlreadyOwned exists
+
+-- | List all packages
+listPackages :: Repository -> IO [Package]
+listPackages repo = do
+  (_, files) <- listDir $ repoPath repo
+  packages <- forM files $ \file -> do
+    either (\(_:: SomeException) -> []) (fromMaybe [] . Aeson.decodeStrict)
+    <$> try (BS.readFile $ toFilePath file)
+  return $ join packages
 
 packageAPI :: Proxy PackageAPI
 packageAPI = Proxy
 
-server :: Server PackageAPI
-server = return [] :<|> return undefined
+server :: Repository -> Server PackageAPI
+server repo = listPackagesHandler :<|> addPackageHandler
+  where
+    listPackagesHandler = liftIO $ listPackages repo
+    addPackageHandler :: Package -> Handler AddPackageResponse
+    addPackageHandler = liftIO . addPackage repo
 
 main :: IO ()
 main = do
-  args <- getArgs
-  case args of
-    [port, gitURL] -> Warp.run 8081 (serve packageAPI server)
-    _ -> fail "Usage: slurp-registry <PORT> <GIT_URL>"
+  args <- unwrapRecord "slurp-registry"
+  repo <- initRepository args
+  Warp.run (args ^. serverPort . non 8081) (serve packageAPI $ server repo)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -121,7 +121,7 @@ initRepository ro = do
   rootDir <- parseAbsDir $ ro ^. repositoryCacheDir . to T.unpack
   cacheDir <- createTempDir rootDir "slurp"
   git <- readCreateProcess (shell "which git") ""
-  callProcess git ["clone", ro ^. repositoryUrl . to T.unpack, toFilePath cacheDir]
+  callProcess "git" ["clone", ro ^. repositoryUrl . to T.unpack, toFilePath cacheDir]
   lock <- newMVar ()
   return $ Repository cacheDir git lock
 

--- a/package.yaml
+++ b/package.yaml
@@ -15,13 +15,23 @@ dependencies:
 - aeson >= 1.2
 - base >= 4.7 && < 5
 - bytestring >= 0.10
+- filepath
+- lens
 - modern-uri >= 0.1
+- optparse-generic
+- path
+- path-io
+- process
 - servant-server >= 0.11
 - servant-swagger >= 1.1
 - text
 - time
+- transformers
 - wai
 - warp
+
+pkg-config-dependencies:
+- zlib
 
 executables:
   slurp-registry-exe:

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+{ pkgs ? import <nixpkgs> {}, ghc ? pkgs.ghc }:
+
+pkgs.haskell.lib.buildStackProject {
+  name = "slurp-repository";
+  inherit ghc;
+  buildInputs = with pkgs; [ zlib ];
+  LANG = "en_GB.UTF-8";
+}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,9 @@
-resolver: lts-10.2
+resolver: lts-10.3
 packages:
 - .
 
+extra-deps:
+  - optparse-generic-1.2.3
+
 nix:
-  packages:
-  - zlib
+  shell-file: shell.nix


### PR DESCRIPTION
This code implements basic working functionality. The code itself needs serious tidying; in particular, error handling is sporadic. It's possible for things to fail silently. This will be easy to fix, but wanted to get this initial version running first.

You can test this by creating an empty 'bare' repo:
``` git init --bare ```
And then cloning it and manually adding a dummy commit (I add a 'meta' directory with a file in. Anything in subdirs is ignored by slurp-registry). If there are no commits in the repo, things will go wrong when we try to sync the repo.

The 'date' parameter is a bit weird. I think we don't want to require it, and instead to fill it automatically. Or just rely on git metadata and drop it entirely.

The 'scheme' parameter should be made optional, and either default to 'Hackage' or infer from the URL. We can then rewrite to add the proxy address on the way out.